### PR TITLE
Fix syntax error in gatsby-node.js

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -19,7 +19,7 @@ exports.modifyWebpackConfig = ({ config, stage }, { logo, icons }) =>
           yandex: true,
           windows: true,
         },
-        icons,
+        icons
       ),
     },
   ])


### PR DESCRIPTION
Removed ',' at the end of line 22 as it was producing a syntax error in the terminal when using `gatsby develop`.