### PR TITLE
List plugin on Gatsby's website

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "keywords": [
     "gatsby",
+    "gatsby-plugin",
     "favicon"
   ],
   "author": "Julien Blatecky <julien.blatecky@creatiwity.net>",


### PR DESCRIPTION
Community plugins needs the "gatsby-plugin" keyword to show up in the search.

see https://github.com/gatsbyjs/gatsby/issues/4394#issuecomment-371659310