### PR TITLE
Only use pathPrefix when --prefix-paths passed to gatsby build

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -18,8 +18,8 @@ exports.onRenderBody = (
   } = pluginOptions
 ) => {
   if (injectHTML) {
-    const prefix = typeof __PATH_PREFIX__ !== 'undefined' ? __PATH_PREFIX__ : ''
-    const HeadComponents = []
+    const prefix = (typeof __PREFIX_PATHS__ !== "undefined" && __PREFIX_PATHS__) ? __PATH_PREFIX__ : '';
+    const HeadComponents = [];
 
     if (android) {
       HeadComponents.push(

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -18,8 +18,8 @@ exports.onRenderBody = (
   } = pluginOptions
 ) => {
   if (injectHTML) {
-    const prefix = (typeof __PREFIX_PATHS__ !== "undefined" && __PREFIX_PATHS__) ? __PATH_PREFIX__ : '';
-    const HeadComponents = [];
+    const prefix = (typeof __PREFIX_PATHS__ !== 'undefined' && __PREFIX_PATHS__) ? __PATH_PREFIX__ : ''
+    const HeadComponents = []
 
     if (android) {
       HeadComponents.push(


### PR DESCRIPTION
Currently the plugin applies pathPrefix whenever the gatsby-config.js file has a value set for it. However this means running ‘gatsby develop’ or ‘gatsby build’ without the ‘—prefix-paths’ flag still uses it and the favicon links don’t resolve correctly.

I’ve changed it to check for ‘—prefix-paths’ and only apply the ‘pathPrefix’ value in this case. This is consistent with how official plug-ins such as ‘gatsby-link’ behave.

This fixes #23 