### PR TITLE
Fix unique key warning on Gatsby build

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,3 +1,4 @@
+const React = require('react')
 const ReactParser = require('html-react-parser');
 const path = require('path');
 const fs = require('fs');
@@ -6,5 +7,18 @@ module.exports.onRenderBody = ({ setHeadComponents }) => {
   const statsPath = path.join(process.cwd(), 'public', '.iconstats.json');
   const stats = JSON.parse(fs.readFileSync(statsPath, {encoding: 'utf8'}));
 
-  setHeadComponents(stats.html.map(htmlRow => ReactParser(htmlRow)));
+  let count = 1;
+
+  const parserOptions = {
+    // Insert key for React on the tags (if not already present)
+    replace: ({ attribs, name }) => {
+      if (attribs && !attribs.hasOwnProperty('key')) {
+        attribs.key = `gatsby-plugin-favicon-${count}`;
+        count++;
+        return React.createElement(name, attribs);
+      }
+    },
+  };
+
+  setHeadComponents(stats.html.map(htmlRow => ReactParser(htmlRow, parserOptions)));
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "html-react-parser": "^0.4.6"
   },
   "peerDependencies": {
-    "gatsby": ">2.0.0-alpha"
+    "gatsby": ">2.0.0-alpha",
+    "react": "^16.4.2"
   }
 }


### PR DESCRIPTION
This should fix the following unique "key" warning caused by the plugin when executing a Gatsby build:
```
Warning: Each child in an array or iterator should have a unique "key" prop.

Check the top-level render call using <head>. See https://fb.me/react-warning-keys for more information.
    in link
    in HTML
```

