### PR TITLE
Adds missing webpack peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "peerDependencies": {
     "gatsby": ">=2.0.0",
+    "webpack": "^3.0.0 || ^4.0.0",
     "react": "^16"
   }
 }


### PR DESCRIPTION
Webpack is a peer dependency of `favicons-webpack-plugin`, so it needs to be a peer dependency of `gatsby-plugin-favicon` as well 🙂